### PR TITLE
Make it generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,4 +208,20 @@ mod tests {
 
         assert_eq!(val.as_deref(), Some(&"Hello"));
     }
+
+    #[test]
+    fn collect() {
+        let input = [([":", "D"], "Hello")];
+
+        let mut d: Dictionary<_, _> = input.into_iter().collect();
+
+        assert_eq!(d.len(), 1);
+
+        let _ = d.partial_find(&":");
+        let _ = d.partial_find(&"D");
+
+        let val = d.try_resolve_path();
+
+        assert_eq!(val.as_deref(), Some(&"Hello"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ mod tests {
     fn insert() {
         let mut d = Dictionary::new();
 
-        d.insert(":D", "Hello");
+        d.insert([":", "D"], "Hello");
 
         assert_eq!(d.len(), 1);
     }
@@ -173,8 +173,8 @@ mod tests {
     fn insert_multiple() {
         let mut d = Dictionary::new();
 
-        d.insert(":D", "Hello");
-        d.insert(":)", "There");
+        d.insert([":", "D"], "Hello");
+        d.insert([":", ")"], "There");
 
         assert_eq!(d.len(), 2);
     }
@@ -183,13 +183,13 @@ mod tests {
     fn find_by_partial_codes() {
         let mut d = Dictionary::new();
 
-        d.insert(":D", "Hello");
+        d.insert([":", "D"], "Hello");
 
-        let _ = d.partial_find(":");
-        let _ = d.partial_find("D");
+        let _ = d.partial_find(&":");
+        let _ = d.partial_find(&"D");
 
         let val = d.try_resolve_path();
 
-        assert_eq!(val.as_deref(), Some("Hello"));
+        assert_eq!(val.as_deref(), Some(&"Hello"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,22 @@ where
     }
 }
 
+impl<KeyParts, K, V> FromIterator<(KeyParts, V)> for Dictionary<K, V>
+where
+    KeyParts: IntoIterator<Item = K>,
+    K: Hash + Eq,
+{
+    fn from_iter<I: IntoIterator<Item = (KeyParts, V)>>(iter: I) -> Self {
+        let mut dictionary = Self::default();
+
+        for (key, value) in iter {
+            dictionary.insert(key, value);
+        }
+
+        dictionary
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Dictionary;


### PR DESCRIPTION
This PR makes the `capillary::Dictionary` generic over the `key` and `value` pairs. The restrictions on `Key` is similar to that of `std::collections::HashMap` found in Rust `std` library.

The usage with `&str` is a little harder by making it so. Will try to make it easier in future updates.